### PR TITLE
changed variables according to new 'free' command

### DIFF
--- a/memory_zabbix_master_item.sh
+++ b/memory_zabbix_master_item.sh
@@ -10,7 +10,7 @@ else
 fi
 
 # Retrieve each element
-#buff and cache value are the same 
+#buff and cache value are assigned by same value
 Total=`echo $MemUsage | awk '{print $1}'`
 Free=`echo $MemUsage | awk '{print $2}'`
 Buff=`echo $MemUsage | awk '{print $3}'`


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/19262583/72496805-1859bb00-3859-11ea-8362-2f33ecb1f7ba.png)

according to free command on centos 7, I changed the value to assign Buff and Cached variables. according to this link (https://sites.google.com/a/thetnaing.com/therunningone/how-to-calculate-systems-memory-utilization), changed the value to assign memory usage total.

MEM_TOTAL=Total-(Free+Buff) buff and cache are the same value so can use Buff or Cached variable.

Sincerely,

